### PR TITLE
Set up ant-based CI

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,25 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
+
+name: Java CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build with Ant
+      run: ant -noinput -buildfile build.xml


### PR DESCRIPTION
This sets up CI for `SigmaUtils`.
Eventually I hope to set up CI for `sigmakee` but it will be much more complex.
For simple project like `SigmaUtils` OOTB github template works fine without any changes. 