### PR TITLE
Add StringUtil.removeFilePath()

### DIFF
--- a/src/java/com/articulate/sigma/utils/StringUtil.java
+++ b/src/java/com/articulate/sigma/utils/StringUtil.java
@@ -601,6 +601,26 @@ public class StringUtil {
     }
 
     /****************************************************************
+     * Strip a full or relative file path down to just the file name,
+     * so two references to the same file (e.g. one from a KB
+     * constituent list, one from a dependency scan run against a
+     * different base directory) compare equal regardless of where each
+     * one was resolved from. Handles both '/' and '\' separators since
+     * paths may originate from either a Unix KB directory or a
+     * Windows-hosted caller. A path with no separator is returned
+     * unchanged; a null or empty input is returned as-is.
+     * @param path A file path, absolute or relative
+     * @return Just the file name portion of path
+     */
+    public static String removeFilePath(String path) {
+
+        if (path == null || path.isEmpty())
+            return path;
+        int lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        return (lastSlash < 0) ? path : path.substring(lastSlash + 1);
+    }
+
+    /****************************************************************
      * @param str A String
      * @return A String with space characters normalized to match the
      * conventions for written English text.  All linefeeds and

--- a/test/unit/java/com/articulate/sigma/utils/StringUtilTest.java
+++ b/test/unit/java/com/articulate/sigma/utils/StringUtilTest.java
@@ -29,6 +29,18 @@ public class StringUtilTest {
     /** *****************************************************************
      */
     @Test
+    public void testRemoveFilePath() {
+
+        assertEquals("Merge.kif", StringUtil.removeFilePath("/home/user/sumo/Merge.kif"));
+        assertEquals("Merge.kif", StringUtil.removeFilePath("C:\\sumo\\Merge.kif"));
+        assertEquals("Merge.kif", StringUtil.removeFilePath("Merge.kif"));
+        assertEquals("", StringUtil.removeFilePath(""));
+        assertEquals(null, StringUtil.removeFilePath(null));
+    }
+
+    /** *****************************************************************
+     */
+    @Test
     public void testIsInteger() {
 
         assertTrue(StringUtil.isInteger("53"));


### PR DESCRIPTION
sigmakee's Diagnostics.java (missingConstituentDependencies / addToDoubleMapList) calls StringUtil.removeFilePath() to normalize KB constituent paths down to bare filenames before comparing them, but the method never existed -- Diagnostics.java currently fails to compile against this version of SigmaUtils.

Strips a full or relative path to its file name, handling both '/' and '\\' separators. jUnit test included (9/9 UnitTestSuite passing, transcript below).

```
[junit] Tests run: 9, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.83 sec
[junit] Testcase: testRemoveFilePath took 0.001 sec
```